### PR TITLE
Fix contracts that are ERC165 and ERC20

### DIFF
--- a/src/lib/ContractParser.js
+++ b/src/lib/ContractParser.js
@@ -158,9 +158,23 @@ export class ContractParser {
     if (includesAll(methods, ['supportsInterface(bytes4)'])) {
       isErc165 = await this.implementsErc165(contract)
     }
-    let interfaces
-    if (isErc165) interfaces = await this.getInterfacesERC165(contract)
-    else interfaces = this.getInterfacesByMethods(methods)
+
+    const interfacesByErc165 = isErc165 ? await this.getInterfacesERC165(contract) : {
+      ERC20: false,
+      ERC677: false,
+      ERC165: false,
+      ERC721: false,
+      ERC721Enumerable: false,
+      ERC721Metadata: false,
+      ERC721Exists: false
+    }
+    const interfacesByMethods = this.getInterfacesByMethods(methods)
+
+    let interfaces = {}
+    Object.keys(interfacesByErc165).forEach(interfaceId => {
+      interfaces[interfaceId] = interfacesByMethods[interfaceId] || interfacesByErc165[interfaceId]
+    })
+
     interfaces = Object.keys(interfaces)
       .filter(k => interfaces[k] === true)
       .map(t => contractsInterfaces[t] || t)

--- a/test/interfaces.spec.js
+++ b/test/interfaces.spec.js
@@ -23,7 +23,8 @@ const addresses = {
   '0x4626f072c42afed36d7aad7f2ab9fa9e16bdb72a': ['ERC165', 'ERC721', 'ERC721Enumerable', 'ERC721Metadata'],
   '0x1e6d0bad215c6407f552e4d1260e7bae90005ab2': ['ERC165', 'ERC721', 'ERC721Enumerable', 'ERC721Metadata'],
   '0xe59f2877a51e570fbf751a07d50899838e6b6cc7': ['ERC721'],
-  '0x7974f2971e0b5d68f30513615fafec5c451da4d1': ['ERC20', 'ERC677']
+  '0x7974f2971e0b5d68f30513615fafec5c451da4d1': ['ERC20', 'ERC677'],
+  '0x06d164e8d6829e1da028a4f745d330eb764dd3ac': ['ERC165', 'ERC20']
 }
 
 const parser = new ContractParser({ nod3 })


### PR DESCRIPTION
Contracts with ERC20 have no support for ERC165 since it was written earlier. This fix makes the tool "merge" the interfaces detected via ERC165 and getCode