### PR TITLE
feat: upgradeable erc20 token support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
     - run: npm ci
-    - run: npm run test:local
+    - run: npm run test
     - run: mv dist/ dist2/
     - run: npm run build
     - run: diff -arq dist/ dist2/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
     - run: npm ci
-    - run: npm run test
+    - run: npm run test:local
     - run: mv dist/ dist2/
     - run: npm run build
     - run: diff -arq dist/ dist2/

--- a/dist/lib/ContractParser.js
+++ b/dist/lib/ContractParser.js
@@ -14,6 +14,17 @@ var _utils = require("./utils");function _interopRequireDefault(obj) {return obj
 
 
 
+function mapInterfacesToERCs(interfaces) {
+  interfaces = Object.keys(interfaces).
+  filter(k => interfaces[k] === true).
+  map(t => _types.contractsInterfaces[t] || t);
+  return interfaces;
+}
+
+function hasMethodSelector(txInputData, selector) {
+  return selector && txInputData ? txInputData.includes(selector) : null;
+}
+
 class ContractParser {
   constructor({ abi, log, initConfig, nod3 } = {}) {
     initConfig = initConfig || {};
@@ -147,17 +158,36 @@ class ContractParser {
     }, {});
   }
 
-  hasMethodSelector(txInputData, selector) {
-    return selector && txInputData ? txInputData.includes(selector) : null;
-  }
+
 
   getMethodsBySelectors(txInputData) {
     let methods = this.getMethodsSelectors();
     return Object.keys(methods).
-    filter(method => this.hasMethodSelector(txInputData, methods[method]) === true);
+    filter(method => hasMethodSelector(txInputData, methods[method]) === true);
   }
 
   async getContractInfo(txInputData, contract) {
+    let { interfaces, methods } = await this.getContractImplementedInterfaces(txInputData, contract);
+
+    interfaces = mapInterfacesToERCs(interfaces);
+    return { methods, interfaces };
+  }
+
+  async getContractInfoIfProxy(contractAddress) {
+    const { isUpgradeable, impContractAddress } = await this.checkForUpgradeableContract(contractAddress);
+    if (isUpgradeable) {
+      // manual check required
+      const proxyContractBytecode = await this.getContractCodeFromNode(impContractAddress);
+      const methods = this.getMethodsBySelectors(proxyContractBytecode);
+      let interfaces = this.getInterfacesByMethods(methods);
+
+      interfaces = mapInterfacesToERCs(interfaces);
+      return { methods, interfaces };
+    }
+    return { methods: [], interfaces: [] };
+  }
+
+  async getContractImplementedInterfaces(txInputData, contract) {
     let methods = this.getMethodsBySelectors(txInputData);
     let isErc165 = false;
     //  skip non-erc165 contracts
@@ -165,12 +195,31 @@ class ContractParser {
       isErc165 = await this.implementsErc165(contract);
     }
     let interfaces;
-    if (isErc165) interfaces = await this.getInterfacesERC165(contract);else
-    interfaces = this.getInterfacesByMethods(methods);
-    interfaces = Object.keys(interfaces).
-    filter(k => interfaces[k] === true).
-    map(t => _types.contractsInterfaces[t] || t);
+    if (isErc165) {
+      interfaces = await this.getInterfacesERC165(contract);
+    } else {
+      interfaces = this.getInterfacesByMethods(methods);
+    }
+
     return { methods, interfaces };
+  }
+
+  async checkForUpgradeableContract(contractAddress) {
+    // check For ERC1967
+    // https://eips.ethereum.org/EIPS/eip-1967
+    // 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc storage address where the implementation address is stored
+    const storedValue = await this.nod3.eth.getStorageAt(contractAddress, '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc');
+    const isUpgradeable = storedValue !== '0x0';
+    if (isUpgradeable) {
+      const impContractAddress = `0x${storedValue.slice(-40)}`; // extract contract address
+      return { isUpgradeable, impContractAddress };
+    } else {
+      return { isUpgradeable, impContractAddress: storedValue };
+    }
+  }
+
+  async getContractCodeFromNode(contractAddress) {
+    return this.nod3.eth.getContractCodeAt(contractAddress);
   }
 
   async getInterfacesERC165(contract) {

--- a/dist/lib/ContractParser.js
+++ b/dist/lib/ContractParser.js
@@ -15,14 +15,13 @@ var _utils = require("./utils");function _interopRequireDefault(obj) {return obj
 
 
 function mapInterfacesToERCs(interfaces) {
-  interfaces = Object.keys(interfaces).
+  return Object.keys(interfaces).
   filter(k => interfaces[k] === true).
   map(t => _types.contractsInterfaces[t] || t);
-  return interfaces;
 }
 
 function hasMethodSelector(txInputData, selector) {
-  return selector && txInputData ? txInputData.includes(selector) : null;
+  return selector && txInputData && txInputData.includes(selector);
 }
 
 class ContractParser {
@@ -173,8 +172,8 @@ class ContractParser {
     return { methods, interfaces };
   }
 
-  async getContractInfoIfProxy(contractAddress) {
-    const { isUpgradeable, impContractAddress } = await this.checkForUpgradeableContract(contractAddress);
+  async getEIP1967Info(contractAddress) {
+    const { isUpgradeable, impContractAddress } = await this.isERC1967(contractAddress);
     if (isUpgradeable) {
       // manual check required
       const proxyContractBytecode = await this.getContractCodeFromNode(impContractAddress);
@@ -204,7 +203,7 @@ class ContractParser {
     return { methods, interfaces };
   }
 
-  async checkForUpgradeableContract(contractAddress) {
+  async isERC1967(contractAddress) {
     // check For ERC1967
     // https://eips.ethereum.org/EIPS/eip-1967
     // 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc storage address where the implementation address is stored

--- a/dist/lib/EventDecoder.js
+++ b/dist/lib/EventDecoder.js
@@ -45,9 +45,11 @@ function EventDecoder(abi, logger) {
 
       const parsedArgs = [];
 
-      for (const i in eventFragment.inputs) parsedArgs.push(
-      encodeElement(eventFragment.inputs[i].type, args[i]));
+      for (const i in eventFragment.inputs) {
+        parsedArgs.push(
+        encodeElement(eventFragment.inputs[i].type, args[i]));
 
+      }
 
       return Object.assign({}, log, {
         signature: (0, _rskUtils.remove0x)(topic),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rsk-contract-parser",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/lib/ContractParser.js
+++ b/src/lib/ContractParser.js
@@ -15,10 +15,9 @@ import {
 } from './utils'
 
 function mapInterfacesToERCs (interfaces) {
-  interfaces = Object.keys(interfaces)
+  return Object.keys(interfaces)
     .filter(k => interfaces[k] === true)
     .map(t => contractsInterfaces[t] || t)
-  return interfaces
 }
 
 function hasMethodSelector (txInputData, selector) {

--- a/src/lib/ContractParser.js
+++ b/src/lib/ContractParser.js
@@ -21,7 +21,7 @@ function mapInterfacesToERCs (interfaces) {
 }
 
 function hasMethodSelector (txInputData, selector) {
-  return (selector && txInputData) ? txInputData.includes(selector) : null
+  return selector && txInputData && txInputData.includes(selector)
 }
 
 export class ContractParser {

--- a/src/lib/ContractParser.js
+++ b/src/lib/ContractParser.js
@@ -172,8 +172,8 @@ export class ContractParser {
     return { methods, interfaces }
   }
 
-  async getContractInfoIfProxy (contractAddress) {
-    const { isUpgradeable, impContractAddress } = await this.checkForUpgradeableContract(contractAddress)
+  async getEIP1967Info (contractAddress) {
+    const { isUpgradeable, impContractAddress } = await this.isERC1967(contractAddress)
     if (isUpgradeable) {
       // manual check required
       const proxyContractBytecode = await this.getContractCodeFromNode(impContractAddress)
@@ -203,7 +203,7 @@ export class ContractParser {
     return { methods, interfaces }
   }
 
-  async checkForUpgradeableContract (contractAddress) {
+  async isERC1967 (contractAddress) {
     // check For ERC1967
     // https://eips.ethereum.org/EIPS/eip-1967
     // 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc storage address where the implementation address is stored

--- a/src/lib/ContractParser.js
+++ b/src/lib/ContractParser.js
@@ -14,6 +14,17 @@ import {
   soliditySignature
 } from './utils'
 
+function mapInterfacesToERCs (interfaces) {
+  interfaces = Object.keys(interfaces)
+    .filter(k => interfaces[k] === true)
+    .map(t => contractsInterfaces[t] || t)
+  return interfaces
+}
+
+function hasMethodSelector (txInputData, selector) {
+  return (selector && txInputData) ? txInputData.includes(selector) : null
+}
+
 export class ContractParser {
   constructor ({ abi, log, initConfig, nod3 } = {}) {
     initConfig = initConfig || {}
@@ -89,8 +100,8 @@ export class ContractParser {
             value.forEach(v => _addresses.push(v))
           } else {
             let i = 0
-            while (2 + (i+1) * 40 <= value.length) {
-              _addresses.push('0x' + value.slice(2 + i * 40, 2 + (i+1) * 40))
+            while (2 + (i + 1) * 40 <= value.length) {
+              _addresses.push('0x' + value.slice(2 + i * 40, 2 + (i + 1) * 40))
               i++
             }
           }
@@ -147,17 +158,36 @@ export class ContractParser {
     }, {})
   }
 
-  hasMethodSelector (txInputData, selector) {
-    return (selector && txInputData) ? txInputData.includes(selector) : null
-  }
+  
 
   getMethodsBySelectors (txInputData) {
     let methods = this.getMethodsSelectors()
     return Object.keys(methods)
-      .filter(method => this.hasMethodSelector(txInputData, methods[method]) === true)
+      .filter(method => hasMethodSelector(txInputData, methods[method]) === true)
   }
 
   async getContractInfo (txInputData, contract) {
+    let { interfaces, methods } = await this.getContractImplementedInterfaces(txInputData, contract)
+
+    interfaces = mapInterfacesToERCs(interfaces)
+    return { methods, interfaces }
+  }
+
+  async getContractInfoIfProxy (contractAddress) {
+    const { isUpgradeable, impContractAddress } = await this.checkForUpgradeableContract(contractAddress)
+    if (isUpgradeable) {
+      // manual check required
+      const proxyContractBytecode = await this.getContractCodeFromNode(impContractAddress)
+      const methods = this.getMethodsBySelectors(proxyContractBytecode)
+      let interfaces = this.getInterfacesByMethods(methods)
+
+      interfaces = mapInterfacesToERCs(interfaces)
+      return { methods, interfaces }
+    }
+    return {methods: [], interfaces: []}
+  }
+
+  async getContractImplementedInterfaces (txInputData, contract) {
     let methods = this.getMethodsBySelectors(txInputData)
     let isErc165 = false
     //  skip non-erc165 contracts
@@ -165,12 +195,31 @@ export class ContractParser {
       isErc165 = await this.implementsErc165(contract)
     }
     let interfaces
-    if (isErc165) interfaces = await this.getInterfacesERC165(contract)
-    else interfaces = this.getInterfacesByMethods(methods)
-    interfaces = Object.keys(interfaces)
-      .filter(k => interfaces[k] === true)
-      .map(t => contractsInterfaces[t] || t)
+    if (isErc165) {
+      interfaces = await this.getInterfacesERC165(contract)
+    } else {
+      interfaces = this.getInterfacesByMethods(methods)
+    }
+
     return { methods, interfaces }
+  }
+
+  async checkForUpgradeableContract (contractAddress) {
+    // check For ERC1967
+    // https://eips.ethereum.org/EIPS/eip-1967
+    // 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc storage address where the implementation address is stored
+    const storedValue = await this.nod3.eth.getStorageAt(contractAddress, '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc')
+    const isUpgradeable = storedValue !== '0x0'
+    if (isUpgradeable) {
+      const impContractAddress = `0x${storedValue.slice(-40)}` // extract contract address
+      return { isUpgradeable, impContractAddress }
+    } else {
+      return { isUpgradeable, impContractAddress: storedValue}
+    }
+  }
+
+  async getContractCodeFromNode (contractAddress) {
+    return this.nod3.eth.getContractCodeAt(contractAddress)
   }
 
   async getInterfacesERC165 (contract) {

--- a/src/lib/EventDecoder.js
+++ b/src/lib/EventDecoder.js
@@ -23,7 +23,7 @@ function EventDecoder (abi, logger) {
       return decoded.toHexString()
     }
     const res = add0x(Buffer.isBuffer(decoded) ? bufferToHex(decoded) : decoded.toString(16))
-    if(type === 'address' || type === 'address[]') return res.toLowerCase()
+    if (type === 'address' || type === 'address[]') return res.toLowerCase()
     return res
   }
 
@@ -45,9 +45,11 @@ function EventDecoder (abi, logger) {
 
       const parsedArgs = []
 
-      for (const i in eventFragment.inputs) parsedArgs.push(
-        encodeElement(eventFragment.inputs[i].type, args[i])
-      )
+      for (const i in eventFragment.inputs) {
+        parsedArgs.push(
+          encodeElement(eventFragment.inputs[i].type, args[i])
+        )
+      }
 
       return Object.assign({}, log, {
         signature: remove0x(topic),

--- a/test/ContractParser.spec.js
+++ b/test/ContractParser.spec.js
@@ -24,7 +24,6 @@ describe("Contract parser", function () {
   }
 
   it("should detect ERC1967 proxy", async () => {
-    // let contract = parser.makeContract("0xc41fe753ff1671b271e34cf1a5ab45c540192abd")
     const info = await parser.getEIP1967Info(
       "0xc41fe753ff1671b271e34cf1a5ab45c540192abd"
     );

--- a/test/ContractParser.spec.js
+++ b/test/ContractParser.spec.js
@@ -1,27 +1,33 @@
-import { assert } from 'chai'
-import { ContractParser } from '../src/lib/ContractParser'
-import nod3 from '../src/lib/nod3Connect'
+import { assert } from "chai";
+import { ContractParser } from "../src/lib/ContractParser";
+import nod3 from "../src/lib/nod3Connect";
 
-const contracts = [
-  '0xebea27d994371cd0cb9896ae4c926bc5221f6317']
+const contracts = ["0xebea27d994371cd0cb9896ae4c926bc5221f6317"];
 
-const parser = new ContractParser({ nod3 })
+const parser = new ContractParser({ nod3 });
 
-describe('# Network', function () {
-  it('should be connected to RSK testnet', async function () {
-    let net = await nod3.net.version()
-    console.log(net)
-    assert.equal(net.id, '31')
-  })
-})
+describe("# Network", function () {
+  it("should be connected to RSK testnet", async function () {
+    let net = await nod3.net.version();
+    console.log(net);
+    assert.equal(net.id, "31");
+  });
+});
 
-describe('Contract parser', function () {
-
+describe("Contract parser", function () {
   for (let address of contracts) {
-    it('should return the token data', async () => {
-      let contract = parser.makeContract(address)
-      const info = await parser.getTokenData(contract)
-      console.log({ info })
-    })
+    it("should return the token data", async () => {
+      let contract = parser.makeContract(address);
+      const info = await parser.getTokenData(contract);
+      console.log({ info });
+    });
   }
-})
+
+  it("should detect ERC1967 proxy", async () => {
+    // let contract = parser.makeContract("0xc41fe753ff1671b271e34cf1a5ab45c540192abd")
+    const info = await parser.getEIP1967Info(
+      "0xc41fe753ff1671b271e34cf1a5ab45c540192abd"
+    );
+    console.log("ERC1967", info);
+  });
+});

--- a/test/ContractParser.spec.js
+++ b/test/ContractParser.spec.js
@@ -22,11 +22,4 @@ describe("Contract parser", function () {
       console.log({ info });
     });
   }
-
-  it("should detect ERC1967 proxy", async () => {
-    const info = await parser.getEIP1967Info(
-      "0xc41fe753ff1671b271e34cf1a5ab45c540192abd"
-    );
-    console.log("ERC1967", info);
-  });
 });


### PR DESCRIPTION
ERC20 tokens that implement an upgradeable pattern, where not showing total supply, tokenSymbol, decimals or token name. 
A new function was added that checks for the standard ERC1967 and, if found, it brings over the implementation details of such implementation contract.