### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rsksmart/rsk-contract-parser",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/rsk-contract-parser",
-      "version": "2.0.9",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rsk-contract-parser",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "A tool to parse/interact with contracts and decode events from the Rootstock blockchain.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This pull request updates the version of `@rsksmart/rsk-contract-parser` in the `package.json` file to reflect a new release. No other changes are included.

* Incremented the package version from `2.0.9` to `2.1.0` in `package.json` to prepare for a new release.