### PR TITLE
feat: support REED bridge abi and update rsk-precompiled-abis dependency

### DIFF
--- a/dist/lib/nativeContracts/bridge-reed.json
+++ b/dist/lib/nativeContracts/bridge-reed.json
@@ -1,0 +1,1548 @@
+[
+  {
+    "name": "getBtcBlockchainBestChainHeight",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int"
+      }
+    ]
+  },
+  {
+    "name": "getStateForBtcReleaseClient",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getStateForSvpClient",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getStateForDebugging",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getBtcBlockchainInitialBlockHeight",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int"
+      }
+    ]
+  },
+  {
+    "name": "getBtcBlockchainBlockHashAtDepth",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "depth",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getBtcTxHashProcessedHeight",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "hash",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int64"
+      }
+    ]
+  },
+  {
+    "name": "isBtcTxHashAlreadyProcessed",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "hash",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ]
+  },
+  {
+    "name": "getFederationAddress",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ]
+  },
+  {
+    "name": "registerBtcTransaction",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "tx",
+        "type": "bytes"
+      },
+      {
+        "name": "height",
+        "type": "int256"
+      },
+      {
+        "name": "pmt",
+        "type": "bytes"
+      }
+    ],
+    "outputs": []
+  },
+  {
+    "name": "addSignature",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "pubkey",
+        "type": "bytes"
+      },
+      {
+        "name": "signatures",
+        "type": "bytes[]"
+      },
+      {
+        "name": "txhash",
+        "type": "bytes"
+      }
+    ],
+    "outputs": []
+  },
+  {
+    "name": "receiveHeaders",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "blocks",
+        "type": "bytes[]"
+      }
+    ],
+    "outputs": []
+  },
+  {
+    "name": "receiveHeader",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "block",
+        "type": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getFederationSize",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getFederationThreshold",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getFederatorPublicKey",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getFederatorPublicKeyOfType",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      },
+      {
+        "name": "type",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getFederationCreationTime",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getFederationCreationBlockNumber",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getRetiringFederationAddress",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ]
+  },
+  {
+    "name": "getRetiringFederationSize",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getRetiringFederationThreshold",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getRetiringFederatorPublicKey",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getRetiringFederatorPublicKeyOfType",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      },
+      {
+        "name": "type",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getRetiringFederationCreationTime",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getRetiringFederationCreationBlockNumber",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "createFederation",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "addFederatorPublicKey",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "addFederatorPublicKeyMultikey",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "btcKey",
+        "type": "bytes"
+      },
+      {
+        "name": "rskKey",
+        "type": "bytes"
+      },
+      {
+        "name": "mstKey",
+        "type": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "commitFederation",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "hash",
+        "type": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "rollbackFederation",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getPendingFederationHash",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getPendingFederationSize",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getPendingFederatorPublicKey",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getPendingFederatorPublicKeyOfType",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      },
+      {
+        "name": "type",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getProposedFederationAddress",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ]
+  },
+  {
+    "name": "getProposedFederationSize",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getProposedFederatorPublicKeyOfType",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      },
+      {
+        "name": "type",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getProposedFederationCreationTime",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getProposedFederationCreationBlockNumber",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getLockWhitelistSize",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getLockWhitelistAddress",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ]
+  },
+  {
+    "name": "getLockWhitelistEntryByAddress",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "address",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "addLockWhitelistAddress",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "address",
+        "type": "string"
+      },
+      {
+        "name": "maxTransferValue",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "addOneOffLockWhitelistAddress",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "address",
+        "type": "string"
+      },
+      {
+        "name": "maxTransferValue",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "addUnlimitedLockWhitelistAddress",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "address",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "removeLockWhitelistAddress",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "address",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "setLockWhitelistDisableBlockDelay",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "disableDelay",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getFeePerKb",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "voteFeePerKbChange",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "feePerKb",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "updateCollections",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [],
+    "outputs": []
+  },
+  {
+    "name": "getMinimumLockTxValue",
+    "type": "function",
+    "stateMutability": "pure",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getBtcTransactionConfirmations",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "txHash",
+        "type": "bytes32"
+      },
+      {
+        "name": "blockHash",
+        "type": "bytes32"
+      },
+      {
+        "name": "merkleBranchPath",
+        "type": "uint256"
+      },
+      {
+        "name": "merkleBranchHashes",
+        "type": "bytes32[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getLockingCap",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "increaseLockingCap",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "newLockingCap",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ]
+  },
+  {
+    "name": "registerBtcCoinbaseTransaction",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "btcTxSerialized",
+        "type": "bytes"
+      },
+      {
+        "name": "blockHash",
+        "type": "bytes32"
+      },  
+      {
+        "name": "pmtSerialized",
+        "type": "bytes"
+      },
+      {
+        "name": "witnessMerkleRoot",
+        "type": "bytes32"
+      }, {
+        "name": "witnessReservedValue",
+        "type": "bytes32"
+      }
+    ],
+    "outputs": []
+  },
+  {
+    "name": "hasBtcBlockCoinbaseTransactionInformation",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "blockHash",
+        "type": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ]
+  },
+  {
+    "name": "registerFastBridgeBtcTransaction",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "btcTxSerialized",
+        "type": "bytes"
+      },
+      {
+        "name": "height",
+        "type": "uint256"
+      }, 
+      {
+        "name": "pmtSerialized",
+        "type": "bytes"
+      },  
+      {
+        "name": "derivationArgumentsHash",
+        "type": "bytes32"
+      },
+      {
+        "name": "userRefundBtcAddress",
+        "type": "bytes"
+      }, 
+      {
+        "name": "liquidityBridgeContractAddress",
+        "type": "address"
+      }, 
+      {
+        "name": "liquidityProviderBtcAddress",
+        "type": "bytes"
+      }, 
+      {
+        "name": "shouldTransferToContract",
+        "type": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getActiveFederationCreationBlockHeight",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "name": "getBtcBlockchainBestBlockHeader",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getBtcBlockchainBlockHeaderByHash",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "btcBlockHash",  
+        "type": "bytes32" 
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getBtcBlockchainBlockHeaderByHeight",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "btcBlockHeight", 
+        "type": "uint256" 
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getBtcBlockchainParentBlockHeaderByHash",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "btcBlockHash", 
+        "type": "bytes32" 
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getEstimatedFeesForNextPegOutEvent",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "name": "getNextPegoutCreationBlockNumber",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "name": "getQueuedPegoutsCount",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "name": "releaseBtc",
+    "type": "function",
+    "stateMutability": "payable",
+    "inputs": [],
+    "outputs": []
+  },
+  {
+    "name": "getActivePowpegRedeemScript",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "setUnionBridgeContractAddressForTestnet",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "unionBridgeContractAddress",
+        "type": "address"
+      }
+    ],
+    "outputs": [
+        {
+            "name": "",
+            "type": "int"
+        }
+    ]
+  },
+  {
+    "name": "getUnionBridgeContractAddress",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ]
+  },
+  {
+    "name": "getUnionBridgeLockingCap",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "name": "increaseUnionBridgeLockingCap",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "newLockingCap",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int"
+      }
+    ]
+  },
+  {
+    "name": "requestUnionBridgeRbtc",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "amountRequested",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int"
+      }
+    ]
+  },
+  {
+    "name": "releaseUnionBridgeRbtc",
+    "type": "function",
+    "stateMutability": "payable",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int"
+      }
+    ]
+  },
+  {
+    "name": "setUnionBridgeTransferPermissions",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "requestEnabled",
+        "type": "bool"
+      },
+      {
+        "name": "releaseEnabled",
+        "type": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int"
+      }
+    ]
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "senderBtcAddress",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "int256"
+      }
+    ],
+    "name": "lock_btc",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "update_collections",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "releaseRskTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "name": "federatorRskAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "federatorBtcPublicKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "add_signature",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "releaseRskTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "btcRawTransaction",
+        "type": "bytes"
+      }
+    ],
+    "name": "release_btc",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "oldFederationBtcPublicKeys",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "name": "oldFederationBtcAddress",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "name": "newFederationBtcPublicKeys",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "name": "newFederationBtcAddress",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "name": "activationHeight",
+        "type": "int256"
+      }
+    ],
+    "name": "commit_federation",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "proposedFederationRedeemScript",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "name": "blockNumber",
+        "type": "int256"
+      }
+    ],
+    "name": "commit_federation_failed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "rskTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "release_requested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "name": "protocolVersion",
+        "type": "int256"
+      }
+    ],
+    "name": "pegin_btc",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "reason",
+        "type": "int256"
+      }
+    ],
+    "name": "rejected_pegin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "reason",
+        "type": "int256"
+      }
+    ],
+    "name": "unrefundable_pegin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "btcDestinationAddress",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "release_request_received",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "reason",
+        "type": "int256"
+      }
+    ],
+    "name": "release_request_rejected",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "releaseRskTxHashes",
+        "type": "bytes"
+      }
+    ],
+    "name": "batch_pegout_created",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "pegoutCreationRskBlockNumber",
+        "type": "uint256"
+      }
+    ],
+    "name": "pegout_confirmed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "utxoOutpointValues",
+        "type": "bytes"
+      }
+    ],
+    "name": "pegout_transaction_created",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "previousLockingCap",
+        "type": "uint256"
+      }
+    ,
+      {
+        "indexed": false,
+        "name": "newLockingCap",
+        "type": "uint256"
+      }
+    ],
+    "name": "union_bridge_locking_cap_increased",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "requester",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "union_rbtc_requested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "union_rbtc_released",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "enablePowPegToUnionBridge",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "name": "enableUnionBridgeToPowPeg",
+        "type": "bool"
+      }
+    ],
+    "name": "union_bridge_transfer_permissions_updated",
+    "type": "event"
+  }
+]

--- a/dist/lib/nativeContracts/bridgeAbi.js
+++ b/dist/lib/nativeContracts/bridgeAbi.js
@@ -4,7 +4,8 @@ var _bridgePapyrus = _interopRequireDefault(require("./bridge-papyrus.json"));
 var _bridgeIris = _interopRequireDefault(require("./bridge-iris.json"));
 var _bridgeFingerroot = _interopRequireDefault(require("./bridge-fingerroot.json"));
 var _bridgeHop = _interopRequireDefault(require("./bridge-hop.json"));
-var _bridgeLovell = _interopRequireDefault(require("./bridge-lovell.json"));function _interopRequireDefault(e) {return e && e.__esModule ? e : { default: e };}
+var _bridgeLovell = _interopRequireDefault(require("./bridge-lovell.json"));
+var _bridgeReed = _interopRequireDefault(require("./bridge-reed.json"));function _interopRequireDefault(e) {return e && e.__esModule ? e : { default: e };}
 
 const RSK_RELEASES = exports.RSK_RELEASES = {
   mainnet: [
@@ -42,6 +43,11 @@ const RSK_RELEASES = exports.RSK_RELEASES = {
     name: 'lovell',
     height: 7338024,
     abi: _bridgeLovell.default
+  },
+  {
+    name: 'reed',
+    height: 8052200,
+    abi: _bridgeReed.default
   }],
 
   testnet: [
@@ -74,6 +80,11 @@ const RSK_RELEASES = exports.RSK_RELEASES = {
     name: 'lovell',
     height: 6110487,
     abi: _bridgeLovell.default
+  },
+  {
+    name: 'reed',
+    height: 6835700,
+    abi: _bridgeReed.default
   }]
 
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@rsksmart/nod3": "^0.5.0",
-        "@rsksmart/rsk-precompiled-abis": "^7.1.0-LOVELL",
+        "@rsksmart/rsk-precompiled-abis": "^8.0.0-REED",
         "@rsksmart/rsk-utils": "^1.1.0",
         "bs58": "^4.0.1",
         "secp256k1": "^3.7.1"
@@ -2142,9 +2142,9 @@
       }
     },
     "node_modules/@rsksmart/rsk-precompiled-abis": {
-      "version": "7.1.0-LOVELL",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rsk-precompiled-abis/-/rsk-precompiled-abis-7.1.0-LOVELL.tgz",
-      "integrity": "sha512-tpNnWXOCYTJG+EMo5bGpkXnyLdRLJ2f7316Lwu+LquQkAS7COQAlBjZn5vTHx3Y1pzAoC8Ylw8r3X0Rlzh87wA=="
+      "version": "8.0.0-REED",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rsk-precompiled-abis/-/rsk-precompiled-abis-8.0.0-REED.tgz",
+      "integrity": "sha512-wKgqrD/8fJOPNRGWY4Gf1N43+W4KSaFhZTool3ZmOkSogfQLl+imnk5wQC8YOIxQy0QJcrvoKtiJBoSQQx4o1g=="
     },
     "node_modules/@rsksmart/rsk-utils": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",
     "@rsksmart/nod3": "^0.5.0",
-    "@rsksmart/rsk-precompiled-abis": "^7.1.0-LOVELL",
+    "@rsksmart/rsk-precompiled-abis": "^8.0.0-REED",
     "@rsksmart/rsk-utils": "^1.1.0",
     "bs58": "^4.0.1",
     "secp256k1": "^3.7.1"

--- a/src/lib/nativeContracts/bridge-reed.json
+++ b/src/lib/nativeContracts/bridge-reed.json
@@ -1,0 +1,1548 @@
+[
+  {
+    "name": "getBtcBlockchainBestChainHeight",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int"
+      }
+    ]
+  },
+  {
+    "name": "getStateForBtcReleaseClient",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getStateForSvpClient",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getStateForDebugging",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getBtcBlockchainInitialBlockHeight",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int"
+      }
+    ]
+  },
+  {
+    "name": "getBtcBlockchainBlockHashAtDepth",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "depth",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getBtcTxHashProcessedHeight",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "hash",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int64"
+      }
+    ]
+  },
+  {
+    "name": "isBtcTxHashAlreadyProcessed",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "hash",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ]
+  },
+  {
+    "name": "getFederationAddress",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ]
+  },
+  {
+    "name": "registerBtcTransaction",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "tx",
+        "type": "bytes"
+      },
+      {
+        "name": "height",
+        "type": "int256"
+      },
+      {
+        "name": "pmt",
+        "type": "bytes"
+      }
+    ],
+    "outputs": []
+  },
+  {
+    "name": "addSignature",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "pubkey",
+        "type": "bytes"
+      },
+      {
+        "name": "signatures",
+        "type": "bytes[]"
+      },
+      {
+        "name": "txhash",
+        "type": "bytes"
+      }
+    ],
+    "outputs": []
+  },
+  {
+    "name": "receiveHeaders",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "blocks",
+        "type": "bytes[]"
+      }
+    ],
+    "outputs": []
+  },
+  {
+    "name": "receiveHeader",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "block",
+        "type": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getFederationSize",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getFederationThreshold",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getFederatorPublicKey",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getFederatorPublicKeyOfType",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      },
+      {
+        "name": "type",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getFederationCreationTime",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getFederationCreationBlockNumber",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getRetiringFederationAddress",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ]
+  },
+  {
+    "name": "getRetiringFederationSize",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getRetiringFederationThreshold",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getRetiringFederatorPublicKey",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getRetiringFederatorPublicKeyOfType",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      },
+      {
+        "name": "type",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getRetiringFederationCreationTime",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getRetiringFederationCreationBlockNumber",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "createFederation",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "addFederatorPublicKey",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "addFederatorPublicKeyMultikey",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "btcKey",
+        "type": "bytes"
+      },
+      {
+        "name": "rskKey",
+        "type": "bytes"
+      },
+      {
+        "name": "mstKey",
+        "type": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "commitFederation",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "hash",
+        "type": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "rollbackFederation",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getPendingFederationHash",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getPendingFederationSize",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getPendingFederatorPublicKey",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getPendingFederatorPublicKeyOfType",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      },
+      {
+        "name": "type",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getProposedFederationAddress",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ]
+  },
+  {
+    "name": "getProposedFederationSize",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getProposedFederatorPublicKeyOfType",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      },
+      {
+        "name": "type",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getProposedFederationCreationTime",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getProposedFederationCreationBlockNumber",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getLockWhitelistSize",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getLockWhitelistAddress",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ]
+  },
+  {
+    "name": "getLockWhitelistEntryByAddress",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "address",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "addLockWhitelistAddress",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "address",
+        "type": "string"
+      },
+      {
+        "name": "maxTransferValue",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "addOneOffLockWhitelistAddress",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "address",
+        "type": "string"
+      },
+      {
+        "name": "maxTransferValue",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "addUnlimitedLockWhitelistAddress",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "address",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "removeLockWhitelistAddress",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "address",
+        "type": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "setLockWhitelistDisableBlockDelay",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "disableDelay",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getFeePerKb",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "voteFeePerKbChange",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "feePerKb",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "updateCollections",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [],
+    "outputs": []
+  },
+  {
+    "name": "getMinimumLockTxValue",
+    "type": "function",
+    "stateMutability": "pure",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getBtcTransactionConfirmations",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "txHash",
+        "type": "bytes32"
+      },
+      {
+        "name": "blockHash",
+        "type": "bytes32"
+      },
+      {
+        "name": "merkleBranchPath",
+        "type": "uint256"
+      },
+      {
+        "name": "merkleBranchHashes",
+        "type": "bytes32[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getLockingCap",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "increaseLockingCap",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "newLockingCap",
+        "type": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ]
+  },
+  {
+    "name": "registerBtcCoinbaseTransaction",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "btcTxSerialized",
+        "type": "bytes"
+      },
+      {
+        "name": "blockHash",
+        "type": "bytes32"
+      },  
+      {
+        "name": "pmtSerialized",
+        "type": "bytes"
+      },
+      {
+        "name": "witnessMerkleRoot",
+        "type": "bytes32"
+      }, {
+        "name": "witnessReservedValue",
+        "type": "bytes32"
+      }
+    ],
+    "outputs": []
+  },
+  {
+    "name": "hasBtcBlockCoinbaseTransactionInformation",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "blockHash",
+        "type": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ]
+  },
+  {
+    "name": "registerFastBridgeBtcTransaction",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "btcTxSerialized",
+        "type": "bytes"
+      },
+      {
+        "name": "height",
+        "type": "uint256"
+      }, 
+      {
+        "name": "pmtSerialized",
+        "type": "bytes"
+      },  
+      {
+        "name": "derivationArgumentsHash",
+        "type": "bytes32"
+      },
+      {
+        "name": "userRefundBtcAddress",
+        "type": "bytes"
+      }, 
+      {
+        "name": "liquidityBridgeContractAddress",
+        "type": "address"
+      }, 
+      {
+        "name": "liquidityProviderBtcAddress",
+        "type": "bytes"
+      }, 
+      {
+        "name": "shouldTransferToContract",
+        "type": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256"
+      }
+    ]
+  },
+  {
+    "name": "getActiveFederationCreationBlockHeight",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "name": "getBtcBlockchainBestBlockHeader",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getBtcBlockchainBlockHeaderByHash",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "btcBlockHash",  
+        "type": "bytes32" 
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getBtcBlockchainBlockHeaderByHeight",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "btcBlockHeight", 
+        "type": "uint256" 
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getBtcBlockchainParentBlockHeaderByHash",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [
+      {
+        "name": "btcBlockHash", 
+        "type": "bytes32" 
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "getEstimatedFeesForNextPegOutEvent",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "name": "getNextPegoutCreationBlockNumber",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "name": "getQueuedPegoutsCount",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "name": "releaseBtc",
+    "type": "function",
+    "stateMutability": "payable",
+    "inputs": [],
+    "outputs": []
+  },
+  {
+    "name": "getActivePowpegRedeemScript",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes"
+      }
+    ]
+  },
+  {
+    "name": "setUnionBridgeContractAddressForTestnet",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "unionBridgeContractAddress",
+        "type": "address"
+      }
+    ],
+    "outputs": [
+        {
+            "name": "",
+            "type": "int"
+        }
+    ]
+  },
+  {
+    "name": "getUnionBridgeContractAddress",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ]
+  },
+  {
+    "name": "getUnionBridgeLockingCap",
+    "type": "function",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ]
+  },
+  {
+    "name": "increaseUnionBridgeLockingCap",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "newLockingCap",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int"
+      }
+    ]
+  },
+  {
+    "name": "requestUnionBridgeRbtc",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "amountRequested",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int"
+      }
+    ]
+  },
+  {
+    "name": "releaseUnionBridgeRbtc",
+    "type": "function",
+    "stateMutability": "payable",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int"
+      }
+    ]
+  },
+  {
+    "name": "setUnionBridgeTransferPermissions",
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "name": "requestEnabled",
+        "type": "bool"
+      },
+      {
+        "name": "releaseEnabled",
+        "type": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int"
+      }
+    ]
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "senderBtcAddress",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "int256"
+      }
+    ],
+    "name": "lock_btc",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "update_collections",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "releaseRskTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "name": "federatorRskAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "federatorBtcPublicKey",
+        "type": "bytes"
+      }
+    ],
+    "name": "add_signature",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "releaseRskTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "btcRawTransaction",
+        "type": "bytes"
+      }
+    ],
+    "name": "release_btc",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "oldFederationBtcPublicKeys",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "name": "oldFederationBtcAddress",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "name": "newFederationBtcPublicKeys",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "name": "newFederationBtcAddress",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "name": "activationHeight",
+        "type": "int256"
+      }
+    ],
+    "name": "commit_federation",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "proposedFederationRedeemScript",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "name": "blockNumber",
+        "type": "int256"
+      }
+    ],
+    "name": "commit_federation_failed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "rskTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "release_requested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "name": "protocolVersion",
+        "type": "int256"
+      }
+    ],
+    "name": "pegin_btc",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "reason",
+        "type": "int256"
+      }
+    ],
+    "name": "rejected_pegin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "reason",
+        "type": "int256"
+      }
+    ],
+    "name": "unrefundable_pegin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "btcDestinationAddress",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "release_request_received",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "reason",
+        "type": "int256"
+      }
+    ],
+    "name": "release_request_rejected",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "releaseRskTxHashes",
+        "type": "bytes"
+      }
+    ],
+    "name": "batch_pegout_created",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "pegoutCreationRskBlockNumber",
+        "type": "uint256"
+      }
+    ],
+    "name": "pegout_confirmed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "btcTxHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "utxoOutpointValues",
+        "type": "bytes"
+      }
+    ],
+    "name": "pegout_transaction_created",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "previousLockingCap",
+        "type": "uint256"
+      }
+    ,
+      {
+        "indexed": false,
+        "name": "newLockingCap",
+        "type": "uint256"
+      }
+    ],
+    "name": "union_bridge_locking_cap_increased",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "requester",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "union_rbtc_requested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "union_rbtc_released",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "enablePowPegToUnionBridge",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "name": "enableUnionBridgeToPowPeg",
+        "type": "bool"
+      }
+    ],
+    "name": "union_bridge_transfer_permissions_updated",
+    "type": "event"
+  }
+]

--- a/src/lib/nativeContracts/bridgeAbi.js
+++ b/src/lib/nativeContracts/bridgeAbi.js
@@ -5,6 +5,7 @@ import iris from './bridge-iris.json'
 import fingerroot from './bridge-fingerroot.json'
 import hop from './bridge-hop.json'
 import lovell from './bridge-lovell.json'
+import reed from './bridge-reed.json'
 
 export const RSK_RELEASES = {
   mainnet: [
@@ -42,6 +43,11 @@ export const RSK_RELEASES = {
       name: 'lovell',
       height: 7338024,
       abi: lovell
+    },
+    {
+      name: 'reed',
+      height: 8052200,
+      abi: reed
     }
   ],
   testnet: [
@@ -74,6 +80,11 @@ export const RSK_RELEASES = {
       name: 'lovell',
       height: 6110487,
       abi: lovell
+    },
+    {
+      name: 'reed',
+      height: 6835700,
+      abi: reed
     }
   ]
 }

--- a/test/bridgeAbi.spec.js
+++ b/test/bridgeAbi.spec.js
@@ -5,6 +5,7 @@ import iris from '../src/lib/nativeContracts/bridge-iris.json'
 import fingerroot from '../src/lib/nativeContracts/bridge-fingerroot.json'
 import hop from '../src/lib/nativeContracts/bridge-hop.json'
 import lovell from '../src/lib/nativeContracts/bridge-lovell.json'
+import reed from '../src/lib/nativeContracts/bridge-reed.json'
 import { getRskReleaseByBlockNumber, RSK_RELEASES } from '../src/lib/nativeContracts/bridgeAbi'
 
 describe('All abis must be in ascendant order', () => {
@@ -30,13 +31,15 @@ describe('getBridgeAbi(txBlockNumber, bitcoinNetwork) should return the correct 
     { height: 1, abi: orchid, name: 'orchid' },
     { height: 3614801, abi: iris, name: 'iris' },
     { height: 5468005, abi: fingerroot, name: 'fingerroot' },
-    { height: 7338024, abi: lovell, name: 'lovell' }
+    { height: 7338024, abi: lovell, name: 'lovell' },
+    { height: 8052200, abi: reed, name: 'reed' }
   ]
   const testnetTestExpectatins = [
     { height: 0, abi: wasabi, name: 'wasabi' },
     { height: 1, abi: wasabi, name: 'wasabi' },
     { height: 3103001, abi: hop, name: 'hop' },
-    { height: 6110487, abi: lovell, name: 'lovell' }
+    { height: 6110487, abi: lovell, name: 'lovell' },
+    { height: 6835700, abi: reed, name: 'reed' }
   ]
 
   for (const { height, abi, name } of mainnetTestExpectations) {

--- a/test/bridgeAbi.spec.js
+++ b/test/bridgeAbi.spec.js
@@ -34,7 +34,7 @@ describe('getBridgeAbi(txBlockNumber, bitcoinNetwork) should return the correct 
     { height: 7338024, abi: lovell, name: 'lovell' },
     { height: 8052200, abi: reed, name: 'reed' }
   ]
-  const testnetTestExpectatins = [
+  const testnetTestExpectations = [
     { height: 0, abi: wasabi, name: 'wasabi' },
     { height: 1, abi: wasabi, name: 'wasabi' },
     { height: 3103001, abi: hop, name: 'hop' },
@@ -49,7 +49,7 @@ describe('getBridgeAbi(txBlockNumber, bitcoinNetwork) should return the correct 
     })
   }
 
-  for (const { height, abi, name } of testnetTestExpectatins) {
+  for (const { height, abi, name } of testnetTestExpectations) {
     it(`Should return ${name} abi for height ${height} in testnet`, () => {
       const release = getRskReleaseByBlockNumber(height, 'testnet')
       expect(release.abi).to.be.deep.equal(abi)
@@ -64,7 +64,7 @@ describe('getBridgeAbi(txBlockNumber, bitcoinNetwork) should return the correct 
     const release1 = getRskReleaseByBlockNumber('latest', 'mainnet')
     const release2 = getRskReleaseByBlockNumber('latest', 'testnet')
     expect(release1.abi).to.be.deep.equal(mainnetTestExpectations[mainnetTestExpectations.length - 1].abi)
-    expect(release2.abi).to.be.deep.equal(testnetTestExpectatins[testnetTestExpectatins.length - 1].abi)
+    expect(release2.abi).to.be.deep.equal(testnetTestExpectations[testnetTestExpectations.length - 1].abi)
   })
 
   it('Should throw an error when block number is not either a number or block tag "latest"', () => {


### PR DESCRIPTION
This pull request updates the bridge ABI support to include the new "reed" release for both mainnet and testnet. The changes ensure the codebase recognizes and properly handles the "reed" ABI at its respective activation block heights, and updates dependencies to use the latest ABI definitions.

**Bridge ABI updates:**

* Added support for the "reed" bridge ABI in `RSK_RELEASES` for mainnet (block 8,052,200) and testnet (block 6,835,700) within `src/lib/nativeContracts/bridgeAbi.js`. [[1]](diffhunk://#diff-6c1af2003407d010d2408a958dac69aafea2d2bfe06ec49b6912d8d8ab8448d3R46-R50) [[2]](diffhunk://#diff-6c1af2003407d010d2408a958dac69aafea2d2bfe06ec49b6912d8d8ab8448d3R83-R87)
* Imported the new `bridge-reed.json` ABI file in both implementation (`src/lib/nativeContracts/bridgeAbi.js`) and test files (`test/bridgeAbi.spec.js`). [[1]](diffhunk://#diff-6c1af2003407d010d2408a958dac69aafea2d2bfe06ec49b6912d8d8ab8448d3R8) [[2]](diffhunk://#diff-c270988f97be4627532a354a9b887652435f8867f2c737d2bbcd3f7964e6cf79R8)

**Dependency update:**

* Updated the `@rsksmart/rsk-precompiled-abis` dependency in `package.json` to version `8.0.0-REED` to use the latest precompiled ABIs.

**Test coverage:**

* Extended test cases in `test/bridgeAbi.spec.js` to include the "reed" ABI for both mainnet and testnet, ensuring correct ABI selection by block height.

**Next version notes:**
We are considering the posibility of moving certain rootstock specific network settings to a dedicated repository (eg: bridge ABI selector logic by blockheight and network)